### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Some contracts link payments against a contract to specific milestones for the d
 
 This extension adds a ```relatedImplementationMilestone``` property to the ```transaction``` object.
 
-The ```relatedImplementationMilestone``` property is a ```milestoneReference``` object.
+The ```relatedImplementationMilestone``` property is a ```MilestoneReference``` object.
 
-The ```milestoneReference``` object is introduced by the [metrics extension](https://github.com/open-contracting/ocds_metrics_extension).
+The ```MilestoneReference``` object is introduced by the [metrics extension](https://github.com/open-contracting/ocds_metrics_extension).
 
 ## Example
 

--- a/versioned-release-validation-schema.json
+++ b/versioned-release-validation-schema.json
@@ -3,14 +3,14 @@
     "Transaction": {
       "properties": {
         "relatedImplementationMilestone": {
-          "$ref": "#/definitions/milestoneReference"
+          "$ref": "#/definitions/MilestoneReference"
         }
       }
     },
     "TransactionUnversioned": {
       "properties": {
         "relatedImplementationMilestone": {
-          "$ref": "#/definitions/milestoneReferenceUnversioned"
+          "$ref": "#/definitions/MilestoneReferenceUnversioned"
         }
       }
     }


### PR DESCRIPTION
As in https://github.com/open-contracting/ocds-shareholders-extension/pull/3, not sure how the references here got mis-cased?