### PR TITLE
Add dependency on metrics extension

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -7,5 +7,8 @@
   },
   "documentationUrl": {
     "en": "https://github.com/open-contracting/ocds_transactions_relatedMilestone_extension"
-  }
+  },
+  "dependencies": [
+    "https://raw.githubusercontent.com/open-contracting/ocds_metrics_extension/master/extension.json"
+  ]
 }


### PR DESCRIPTION
otherwise /definitions/MilestoneReference is unresolvable

https://github.com/open-contracting/standard-maintenance-scripts/issues/49